### PR TITLE
Add python 3.8.6 constraint to whitesource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,8 @@
       "packagePatterns": ["pytest"],
       "updateTypes": ["minor", "major"]
     }
-  ]
+  ],
+  "constraints": {
+    "python": "3.8.6"
+  }
 }


### PR DESCRIPTION
Supersedes #14 

In theory, this change should pin the Python version to 3.8.6, which matches the version of Python Cloud Buildpacks uses. This should prevent automated PRs from whitesource like #14 trying to bump this dependency.