### PR TITLE
refactor(tasks): Variabilize deployment region in tasks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -27,6 +27,7 @@ from invoke import task
 
 venv = "source ./venv/bin/activate"
 GOOGLE_CLOUD_PROJECT = os.environ.get("GOOGLE_CLOUD_PROJECT")
+REGION = os.environ.get("REGION", "us-central1")
 
 
 @task
@@ -119,7 +120,7 @@ def build(c):  # noqa: ANN001, ANN201
     """Build the service into a container image"""
     c.run(
         f"gcloud builds submit --pack "
-        f"image=us-central1-docker.pkg.dev/{GOOGLE_CLOUD_PROJECT}/samples/microservice-template:manual"
+        f"image={REGION}-docker.pkg.dev/{GOOGLE_CLOUD_PROJECT}/samples/microservice-template:manual"
     )
 
 
@@ -128,8 +129,8 @@ def deploy(c):  # noqa: ANN001, ANN201
     """Deploy the container into Cloud Run (fully managed)"""
     c.run(
         "gcloud run deploy microservice-template "
-        f"--image us-central1-docker.pkg.dev/{GOOGLE_CLOUD_PROJECT}/samples/microservice-template:manual "
-        "--platform managed --region us-central1"
+        f"--image {REGION}-docker.pkg.dev/{GOOGLE_CLOUD_PROJECT}/samples/microservice-template:manual "
+        f"--platform managed --region {REGION}"
     )
 
 


### PR DESCRIPTION
# Problem

- When running tasks `build` and `deploy` with `invoke`, it uses the `us-central1` as the region, even though it's not the region set in the bash (with `export REGION=...`)

# Solution

- [x] In the build & deploy tasks, use the region set in the environment variable
- [x] If the region is not set, default to `us-central1` keeping backward compatibility