### PR TITLE
chore: update to use latest buildpack

### DIFF
--- a/test/advance.cloudbuild.yaml
+++ b/test/advance.cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
     args:
       - build
       - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA" # Tag docker image with git commit SHA
-      - "--builder=gcr.io/buildpacks/builder:v1"
+      - "--builder=gcr.io/buildpacks/builder:latest"
       - "--path=."
       - "-v"
       - "--publish"


### PR DESCRIPTION
Update buildpack version to use "latest" OS instead of pinning OS version. 
Goals: Keep OS up to date to reduce CVE, but removes best practices of pinning versions for consistent builds.